### PR TITLE
NF-1560: Fix LPUART bugs.

### DIFF
--- a/System/Core/Inc/main.h
+++ b/System/Core/Inc/main.h
@@ -10,18 +10,19 @@
 #include "stm32l4xx_hal.h"
 #include "board.h"
 
-// Peripherals (please update MY_ActivePeripherals()
-#define PERIPHERAL_RNG		0x00000001
-#define PERIPHERAL_USB		0x00000002
-#define PERIPHERAL_ADC1		0x00000004
-#define PERIPHERAL_CAN1		0x00000008
-#define PERIPHERAL_LPUART1  0x00000010
-#define PERIPHERAL_USART1   0x00000020
-#define PERIPHERAL_USART2   0x00000040
-#define PERIPHERAL_I2C1     0x00000080
-#define PERIPHERAL_I2C3     0x00000100
-#define PERIPHERAL_SPI1     0x00000200
-#define PERIPHERAL_SPI2     0x00000400
+// Peripherals (please update MX_ActivePeripherals()
+#define PERIPHERAL_RNG           0x00000001
+#define PERIPHERAL_USB           0x00000002
+#define PERIPHERAL_ADC1          0x00000004
+#define PERIPHERAL_CAN1          0x00000008
+#define PERIPHERAL_LPUART1       0x00000010
+#define PERIPHERAL_USART1        0x00000020
+#define PERIPHERAL_USART2        0x00000040
+#define PERIPHERAL_I2C1          0x00000080
+#define PERIPHERAL_I2C3          0x00000100
+#define PERIPHERAL_SPI1          0x00000200
+#define PERIPHERAL_SPI2          0x00000400
+#define PERIPHERAL_LPUART1_PCLK1 0x00000800
 
 // global
 size_t strlcpy(char *dst, const char *src, size_t siz);

--- a/System/Core/Src/main.c
+++ b/System/Core/Src/main.c
@@ -198,7 +198,9 @@ void MX_ActivePeripherals(char *buf, uint32_t buflen)
     if ((peripherals & PERIPHERAL_SPI2) != 0) {
         strlcat(buf, "SPI2 ", buflen);
     }
-
+    if ((peripherals & PERIPHERAL_LPUART1_PCLK1) != 0) {
+        strlcat(buf, "LPUART1_PCLK1 ", buflen);
+    }
 }
 
 // Get the image size


### PR DESCRIPTION
- MX_LPUART1_UART_Init needs to change the LPUART clock source if needed to support the given baud rate.
- MX_LPUART1_UART_DeInit was mistakenly calling __HAL_RCC_USART1_FORCE_RESET and __HAL_RCC_USART1_RELEASE_RESET instead of __HAL_RCC_LPUART1_FORCE_RESET and __HAL_RCC_LPUART1_RELEASE_RESET.